### PR TITLE
height should be specified at 100% because of overflow errors

### DIFF
--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -148,6 +148,7 @@ export class Titlebar extends Themebar {
 		this.container.style.left = '0';
 		this.container.style.position = 'absolute';
 		this.container.style.overflow = 'auto';
+		this.container.style.height = '100%';
 
 		while (document.body.firstChild) {
 			append(this.container, document.body.firstChild);


### PR DESCRIPTION
I encountered an error where an extra scrollbar was being added to my app because the container was getting larger than 100%. This should never happen because this container should just be a mirror of the screen basically.